### PR TITLE
feat: switch to FingerprintJS Pro version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@commitlint/cli": "19.5.0",
         "@commitlint/config-conventional": "19.5.0",
-        "@fingerprintjs/fingerprintjs": "4.5.1",
+        "@fingerprintjs/fingerprintjs-pro": "3.11.3",
         "@release-it/conventional-changelog": "9.0.2",
         "@storybook/addon-essentials": "8.4.1",
         "@storybook/addon-interactions": "8.4.1",
@@ -1191,10 +1191,10 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@fingerprintjs/fingerprintjs": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs/-/fingerprintjs-4.5.1.tgz",
-      "integrity": "sha512-hKJaRoLHNeUUPhb+Md3pTlY/Js2YR4aXjroaDHpxrjoM8kGnEFyZVZxXo6l3gRyKnQN52Uoqsycd3M73eCdMzw==",
+    "node_modules/@fingerprintjs/fingerprintjs-pro": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.11.3.tgz",
+      "integrity": "sha512-ulpDKLT0bFcB8OcR3ppVUFRHMKTQRk45m0bTXmUEW4GytUcWbdKVZwQEvn5/jL9QKInVN1y09En4sBXk4JlaAQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@commitlint/cli": "19.5.0",
     "@commitlint/config-conventional": "19.5.0",
-    "@fingerprintjs/fingerprintjs": "4.5.1",
+    "@fingerprintjs/fingerprintjs-pro": "3.11.5",
     "@release-it/conventional-changelog": "9.0.2",
     "@storybook/addon-essentials": "8.4.1",
     "@storybook/addon-interactions": "8.4.1",

--- a/src/services/pix/BelvoPaymentsAtomsPix.ts
+++ b/src/services/pix/BelvoPaymentsAtomsPix.ts
@@ -5,7 +5,7 @@ import {
   BiometricRegistrationRequest,
   EnrollmentInformation
 } from '@/types/pix'
-import FingerprintJS from '@fingerprintjs/fingerprintjs'
+import FingerprintJS from '@fingerprintjs/fingerprintjs-pro'
 import {
   AuthenticationPublicKeyCredential,
   AuthenticationResponseJSON,
@@ -29,7 +29,15 @@ const padTimeZoneOfsset = (number: number, totalDigits = 2, paddingCharacter = '
   ['', '-'][+(number < 0)] +
   (paddingCharacter.repeat(totalDigits) + Math.abs(number)).slice(-1 * totalDigits)
 const getDeviceId = async (): Promise<string> => {
-  const fp = await FingerprintJS.load()
+  /**
+   * This API Key is a public key, it's not a secret.
+   * It's used to submit requests to the FingerprintJS API.
+   *
+   * In the FingerprintJS Dashboard, we have configured an origin allowlist
+   * so we can only submit requests from our own domains. Any request from
+   * a different origin will be rejected to prevent misuse of the API.
+   */
+  const fp = await FingerprintJS.load({ apiKey: 'nVbyx8oY47QzBtYJg0wX' })
   const result = await fp.get()
 
   return result.visitorId
@@ -124,7 +132,6 @@ const authenticateCredential = async (
     throw new Error(`Error during credential authentication: ${error}`)
   }
 }
-
 const buildCredentialAuthenticationOptions = (
   authenticationRequest: BiometricPaymentRequest
 ): CredentialRequestOptions => {


### PR DESCRIPTION
What
---
- Switch to FingerprintJS Pro version

Why
---
We need to perform real tests now. FingerprintJS pro version guarantees a longer durability of the deviceID and we will use it as fingerprinting tool.