### PR TITLE
fix: return empty string instead of null for userHandle

### DIFF
--- a/src/services/pix/BelvoPaymentsAtomsPix.ts
+++ b/src/services/pix/BelvoPaymentsAtomsPix.ts
@@ -150,7 +150,7 @@ const buildCredentialAuthenticationResult = (
       authenticatorData: json.response.authenticatorData,
       clientDataJSON: json.response.clientDataJSON,
       signature: json.response.signature,
-      userHandle: json.response.userHandle || null
+      userHandle: json.response.userHandle || ''
     },
     type: json.type
   } as BiometricAuthorization


### PR DESCRIPTION
What
---
- Return userHandle as empty string instead of null.

Why
---
According to the Open Finance documentation, if the userHandle field is not present, it should be an empty string. Returning it empty in the SDK makes it easier to handle the payload when using it.
