### PR TITLE
feat: add authenticatorSelection and excludeCredentials to CredentialCreationOptions

### DIFF
--- a/src/services/pix/BelvoPaymentsAtomsPix.ts
+++ b/src/services/pix/BelvoPaymentsAtomsPix.ts
@@ -98,7 +98,9 @@ const buildCredentialCreationOptions = (
       user: registrationRequest.user,
       pubKeyCredParams: registrationRequest.pubKeyCredParams,
       timeout: 60000,
-      attestation: registrationRequest.attestation
+      attestation: registrationRequest.attestation,
+      authenticatorSelection: registrationRequest.authenticatorSelection,
+      excludeCredentials: registrationRequest.excludeCredentials
     }
   } as CredentialCreationOptionsJSON
 


### PR DESCRIPTION
What
---
add authenticatorSelection and excludeCredentials to CredentialCreationOptions

Why
---
The clients of the SDK should be able to send the info