### PR TITLE
fix: revert hardcoded fido options

### DIFF
--- a/src/services/pix/BelvoPaymentsAtomsPix.ts
+++ b/src/services/pix/BelvoPaymentsAtomsPix.ts
@@ -98,9 +98,7 @@ const buildCredentialCreationOptions = (
       user: registrationRequest.user,
       pubKeyCredParams: registrationRequest.pubKeyCredParams,
       timeout: 60000,
-      attestation: registrationRequest.attestation,
-      authenticatorSelection: registrationRequest.authenticatorSelection,
-      excludeCredentials: registrationRequest.excludeCredentials
+      attestation: registrationRequest.attestation
     }
   } as CredentialCreationOptionsJSON
 


### PR DESCRIPTION
What
---
- Remove hardcooded fido options.

Why
---
This broke the usage of the webauthn API for some banks. Revcerting for now to test Nubank.