### PR TITLE
feat: expose getDevice and remove deviceId from collectEnrollmentInformation response

### DIFF
--- a/schemas/open-api/pix.yaml
+++ b/schemas/open-api/pix.yaml
@@ -100,9 +100,6 @@ components:
       type: object
     EnrollmentInformation:
       properties:
-        deviceId:
-          title: EnrollmentInformation.deviceId
-          type: string
         osVersion:
           title: EnrollmentInformation.osVersion
           type: string

--- a/src/components/main.spec.ts
+++ b/src/components/main.spec.ts
@@ -1,6 +1,12 @@
 import BelvoPaymentsGrid from '@/components/paymentsGrid/BelvoPaymentsGrid.ce.vue'
 import BelvoPaymentsAtomsOptions from '@/services/options/BelvoPaymentsAtomsOptions'
-import { isWebAuthnSupported, login, register, signals } from '@/services/pix/BelvoPaymentsAtomsPix'
+import {
+  getDevice,
+  isWebAuthnSupported,
+  login,
+  register,
+  signals
+} from '@/services/pix/BelvoPaymentsAtomsPix'
 import { defineWebComponents } from '@/utils/webComponents/webComponentsUtils'
 import BelvoPaymentsAtoms, { InitializationOptions } from './main'
 
@@ -37,6 +43,7 @@ describe('main.spec.ts', () => {
   describe('biometricPix', () => {
     it('should return signals and register', () => {
       expect(BelvoPaymentsAtoms.biometricPix).toEqual({
+        getDevice: getDevice,
         collectEnrollmentInformation: signals,
         requestEnrollmentConfirmation: register,
         authorizePayment: login,

--- a/src/components/main.ts
+++ b/src/components/main.ts
@@ -1,6 +1,12 @@
 import BelvoPaymentsGrid from '@/components/paymentsGrid/BelvoPaymentsGrid.ce.vue'
 import BelvoPaymentsAtomsOptions from '@/services/options/BelvoPaymentsAtomsOptions'
-import { isWebAuthnSupported, login, register, signals } from '@/services/pix/BelvoPaymentsAtomsPix'
+import {
+  getDevice,
+  isWebAuthnSupported,
+  login,
+  register,
+  signals
+} from '@/services/pix/BelvoPaymentsAtomsPix'
 import type { InitializationOptions } from '@/types/lib'
 import { defineWebComponents, type Component } from '@/utils/webComponents/webComponentsUtils'
 
@@ -15,6 +21,7 @@ export default {
     defineWebComponents([{ name: 'belvo-payments-grid', setup: BelvoPaymentsGrid as Component }])
   },
   biometricPix: {
+    getDevice: getDevice,
     collectEnrollmentInformation: signals,
     requestEnrollmentConfirmation: register,
     authorizePayment: login,

--- a/src/types/pix.ts
+++ b/src/types/pix.ts
@@ -30,7 +30,6 @@ export type BiometricPaymentRequest = {
 }
 
 export type EnrollmentInformation = {
-  deviceId: string
   osVersion: string
   userTimeZoneOffset: string
   language: string
@@ -62,4 +61,9 @@ export type BiometricRegistrationConfirmation = {
     clientDataJSON: string
   }
   type: string
+}
+
+export type DeviceInformation = {
+  visitorId: string
+  sealedResult?: string
 }


### PR DESCRIPTION
What
---
- expose `getDevice` with visitorId and `sealedResult` from fingerprint
- remove `deviceId` from `collectEnrollmentInformation` response

Why
---
- we need to be able to get the deviceId from other places in the flow so we need to expose it, and by needing it somewhere else we need to remove it from the place we're using it
