### PR TITLE
fix: force '+' sign for positive timezone offsets

### DIFF
--- a/src/services/pix/BelvoPaymentsAtomsPix.ts
+++ b/src/services/pix/BelvoPaymentsAtomsPix.ts
@@ -20,41 +20,8 @@ import {
   get as webauthnGet,
   supported as webauthnSupported
 } from '@github/webauthn-json/browser-ponyfill'
-import { isValid, parse } from 'date-fns'
-import { getTimezoneOffset } from 'date-fns-tz'
-import { UAParser } from 'ua-parser-js'
 import { handleBiometricError, handleCredentialNotFound } from './errors'
-
-// Risk Signals
-const isValidDate = (date: string): boolean => isValid(parse(date, 'yyyy-MM-dd', new Date()))
-
-const padTimeZoneOfsset = (number: number, totalDigits = 2, paddingCharacter = '0') =>
-  ['', '-'][+(number < 0)] +
-  (paddingCharacter.repeat(totalDigits) + Math.abs(number)).slice(-1 * totalDigits)
-
-const buildSignals = async (accountTenure: string): Promise<EnrollmentInformation> => {
-  const userAgentParser = new UAParser(navigator.userAgent)
-  const milisecondsToHours = (miliseconds: number): number => miliseconds / 1000 / 60 / 60
-  const getUserTimeZoneOffset = () =>
-    padTimeZoneOfsset(
-      milisecondsToHours(
-        getTimezoneOffset(Intl.DateTimeFormat().resolvedOptions().timeZone, new Date())
-      ),
-      2
-    )
-  const osVersion = `${userAgentParser.getOS().name} ${userAgentParser.getOS().version}`
-
-  return {
-    osVersion,
-    userTimeZoneOffset: getUserTimeZoneOffset(),
-    language: navigator.language.substring(0, 2),
-    screenDimensions: {
-      height: window.screen.height,
-      width: window.screen.width
-    },
-    accountTenure
-  }
-}
+import { buildSignals } from './riskSignals'
 
 // Creation
 const createCredential = async (
@@ -208,8 +175,6 @@ export const login = async (
 }
 
 export const signals = async (accountTenure: string): Promise<EnrollmentInformation> => {
-  if (!isValidDate(accountTenure)) throw new Error('Invalid account tenure')
-
   return await buildSignals(accountTenure)
 }
 

--- a/src/services/pix/riskSignals.spec.ts
+++ b/src/services/pix/riskSignals.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import { _getSignedAndPaddedOffset, getUserTimeZoneOffset } from './riskSignals'
+
+describe('Timezone offset functions', () => {
+  describe('_getSignedAndPaddedOffset', () => {
+    it('should pad and add sign to single digit positive numbers', () => {
+      expect(_getSignedAndPaddedOffset(3)).toBe('+03')
+      expect(_getSignedAndPaddedOffset(9)).toBe('+09')
+    })
+
+    it('should pad and add sign to single digit negative numbers', () => {
+      expect(_getSignedAndPaddedOffset(-3)).toBe('-03')
+      expect(_getSignedAndPaddedOffset(-9)).toBe('-09')
+    })
+
+    it('should pad and add sign to double digit numbers', () => {
+      expect(_getSignedAndPaddedOffset(12)).toBe('+12')
+      expect(_getSignedAndPaddedOffset(-12)).toBe('-12')
+    })
+
+    it('should pad and add positive sign to zero', () => {
+      expect(_getSignedAndPaddedOffset(0)).toBe('+00')
+    })
+  })
+
+  describe('getUserTimeZoneOffset', () => {
+    describe('Daylight Saving Time', () => {
+      it('should return correct offset for UTC (no DST)', () => {
+        const date = new Date('2024-07-01')
+        expect(getUserTimeZoneOffset('UTC', date)).toBe('+00')
+      })
+
+      it('should return correct offset for São Paulo during DST', () => {
+        const date = new Date('2015-12-01')
+        expect(getUserTimeZoneOffset('America/Sao_Paulo', date)).toBe('-02')
+      })
+
+      it('should return correct offset for Spain during DST', () => {
+        const date = new Date('2024-07-01')
+        expect(getUserTimeZoneOffset('Europe/Madrid', date)).toBe('+02')
+      })
+    })
+
+    describe('Normal Time', () => {
+      it('should return correct offset for UTC (no DST)', () => {
+        const date = new Date('2024-12-01')
+        expect(getUserTimeZoneOffset('UTC', date)).toBe('+00')
+      })
+
+      it('should return correct offset for São Paulo during normal time', () => {
+        const date = new Date('2024-12-01')
+        expect(getUserTimeZoneOffset('America/Sao_Paulo', date)).toBe('-03')
+      })
+
+      it('should return correct offset for Spain during normal time', () => {
+        const date = new Date('2025-01-01')
+        expect(getUserTimeZoneOffset('Europe/Madrid', date)).toBe('+01')
+      })
+    })
+  })
+})

--- a/src/services/pix/riskSignals.ts
+++ b/src/services/pix/riskSignals.ts
@@ -1,0 +1,61 @@
+import { EnrollmentInformation } from '@/types/pix'
+import { isValid, parse } from 'date-fns'
+import { getTimezoneOffset } from 'date-fns-tz'
+import { UAParser } from 'ua-parser-js'
+
+const isValidDate = (date: string): boolean => isValid(parse(date, 'yyyy-MM-dd', new Date()))
+
+/**
+ * Get the signed and padded timezone offset
+ * @param offsetHours - The timezone offset in hours (e.g. -3 for UTC-3)
+ * @returns The signed and padded timezone offset as a string, e.g. '-03'
+ */
+export const _getSignedAndPaddedOffset = (offsetHours: number) => {
+  // Remove the sign for padding
+  const abs = Math.abs(offsetHours)
+  const paddedOffset = (abs < 10 ? '0' : '') + abs
+
+  // Add the sign back
+  const sign = offsetHours < 0 ? '-' : '+'
+
+  return `${sign}${paddedOffset}`
+}
+
+/**
+ * Get the timezone offset for a given date and time zone
+ * @param timeZone - The time zone to get the offset for (IANA format, e.g. 'America/Sao_Paulo')
+ * @param date - The date to get the offset for
+ * @returns The timezone offset as a string, e.g. '-03'
+ */
+export const getUserTimeZoneOffset = (timeZone: string, date: Date) => {
+  const offsetMillis = getTimezoneOffset(timeZone, date)
+  const offsetHours = offsetMillis / 1000 / 60 / 60
+
+  return _getSignedAndPaddedOffset(offsetHours)
+}
+
+/**
+ * Build the risk signals for the enrollment
+ * @param accountTenure - The account tenure in YYYY-MM-DD format
+ * @returns All risk signals needed for a browser JSR flow
+ */
+export const buildSignals = async (accountTenure: string): Promise<EnrollmentInformation> => {
+  if (!isValidDate(accountTenure)) throw new Error('Invalid account tenure')
+
+  const userAgentParser = new UAParser(navigator.userAgent)
+  const osVersion = `${userAgentParser.getOS().name} ${userAgentParser.getOS().version}`
+
+  return {
+    osVersion,
+    userTimeZoneOffset: getUserTimeZoneOffset(
+      Intl.DateTimeFormat().resolvedOptions().timeZone,
+      new Date()
+    ),
+    language: navigator.language.substring(0, 2),
+    screenDimensions: {
+      height: window.screen.height,
+      width: window.screen.width
+    },
+    accountTenure
+  }
+}


### PR DESCRIPTION
What
---
- Ensure positive timezone offsets are generated as +03, instead of 03.
- Simplify user timezone information generation.
- Extract risk signals code to a dedicated file.
- Add tests for timezone offset operations.

Why
---
The international IANA standard is to used signed timezone offsets, and this is also required by the Open Finance standard.