### PR TITLE
feat: enforce webauthn parameters for enhanced widget experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ coverage
 
 # Storybook
 storybook-static
+
+# Environment variables
+.env

--- a/examples/biometricPix/playground/.env.example
+++ b/examples/biometricPix/playground/.env.example
@@ -1,0 +1,2 @@
+# Relying Party ID for WebAuthn
+VITE_RP_ID=belvo.com 

--- a/examples/biometricPix/playground/README.md
+++ b/examples/biometricPix/playground/README.md
@@ -6,7 +6,7 @@ This playground was created to help you debug the [Webauthn API](https://develop
 
 Make sure to have Node.js installed.
 
-## Project Setup
+## Getting started
 
 As you may know, you need a SSL connection and a valid domain to be able to test the Webauthn API.
 
@@ -28,7 +28,13 @@ After that, you can build the project with:
 npm run build
 ```
 
-And then, go to your `./dist` folder and run:
+or
+
+```sh
+npm run watch
+```
+
+Then, go to your `./dist` folder and run:
 
 ```sh
 npx http-server
@@ -42,10 +48,19 @@ After that, it's time to run Caddy. Open a new terminal window, go to the playgr
 caddy run
 ```
 
-You might need to open a new terminal window to allow caddy to create the certificates for you. You should run the following command (just one time) while having Caddy running:
+You might need to open a second terminal window to allow caddy to create the certificates for you. You should run the following command (one-time only) while having Caddy running:
 
 ```sh
 caddy trust
 ```
 
 That is all. You should now be able to navigate to <https://bio.localhost> and start playing around. Have fun!
+
+## Testing on mobile
+
+There are several ways to test the Playground on mobile devices. We recommend using [ngrok](https://ngrok.com/docs/getting-started/), which will create a secure public HTTPS URL for you to easily access the Playground from any device.
+Follow ngrok's installation instructions and run it locally with the following command:
+
+```sh
+ngrok http 8080 --url=my-free-url.ngrok-free.app
+```

--- a/examples/biometricPix/playground/README.md
+++ b/examples/biometricPix/playground/README.md
@@ -56,6 +56,22 @@ caddy trust
 
 That is all. You should now be able to navigate to <https://bio.localhost> and start playing around. Have fun!
 
+## Environment Setup
+
+Copy the environment example file to create your local environment file:
+
+```bash
+cp .env.example .env
+```
+
+Configure your environment variables in according to the table below.
+
+### Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `RP_ID` | The Relying Party ID for WebAuthn | `bio.localhost` |
+
 ## Testing on mobile
 
 There are several ways to test the Playground on mobile devices. We recommend using [ngrok](https://ngrok.com/docs/getting-started/), which will create a secure public HTTPS URL for you to easily access the Playground from any device.

--- a/examples/biometricPix/playground/index.html
+++ b/examples/biometricPix/playground/index.html
@@ -2,7 +2,7 @@
 <html lang="">
   <head>
     <meta charset="UTF-8">
-    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="../favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Biometric PIX - Playground</title>
   </head>

--- a/examples/biometricPix/playground/package-lock.json
+++ b/examples/biometricPix/playground/package-lock.json
@@ -11,7 +11,7 @@
         "vue": "^3.5.12"
       },
       "devDependencies": {
-        "@belvo/payments-atoms": "latest",
+        "@belvo/payments-atoms": "file:../../../",
         "@eslint/js": "^9.14.0",
         "@vitejs/plugin-vue": "^5.1.4",
         "@vue/eslint-config-prettier": "^10.1.0",
@@ -19,6 +19,77 @@
         "eslint-plugin-vue": "^9.30.0",
         "prettier": "^3.3.3",
         "vite": "^5.4.10"
+      }
+    },
+    "../../..": {
+      "name": "@belvo/payments-atoms",
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@github/webauthn-json": "^2.1.1",
+        "vue": "3.5.12"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "19.5.0",
+        "@commitlint/config-conventional": "19.5.0",
+        "@fingerprintjs/fingerprintjs-pro": "3.11.5",
+        "@release-it/conventional-changelog": "9.0.2",
+        "@storybook/addon-essentials": "8.4.1",
+        "@storybook/addon-interactions": "8.4.1",
+        "@storybook/addon-links": "8.4.1",
+        "@storybook/blocks": "8.4.1",
+        "@storybook/test": "8.4.1",
+        "@storybook/vue3": "8.4.1",
+        "@storybook/vue3-vite": "8.4.1",
+        "@tsconfig/node18": "18.2.4",
+        "@types/jsdom": "21.1.7",
+        "@types/node": "22.8.6",
+        "@types/ua-parser-js": "0.7.39",
+        "@types/uuid": "10.0.0",
+        "@types/webappsec-credential-management": "0.6.9",
+        "@vitejs/plugin-vue": "5.1.4",
+        "@vitest/coverage-v8": "2.1.4",
+        "@vue/eslint-config-prettier": "10.1.0",
+        "@vue/eslint-config-typescript": "14.1.3",
+        "@vue/test-utils": "2.4.6",
+        "@vue/tsconfig": "0.5.1",
+        "ajv": "8.17.1",
+        "auto-changelog": "2.5.0",
+        "autoprefixer": "10.4.20",
+        "commitlint-plugin-function-rules": "4.0.0",
+        "date-fns": "4.1.0",
+        "date-fns-tz": "3.2.0",
+        "eslint": "9.13.0",
+        "eslint-plugin-no-only-tests": "3.3.0",
+        "eslint-plugin-storybook": "0.10.2",
+        "eslint-plugin-unused-imports": "4.1.4",
+        "eslint-plugin-vue": "9.30.0",
+        "eslint-plugin-vue-scoped-css": "2.8.1",
+        "globals": "15.11.0",
+        "husky": "9.1.6",
+        "is-ci": "3.0.1",
+        "jsdom": "25.0.1",
+        "lint-staged": "15.2.10",
+        "npm-run-all2": "7.0.1",
+        "postcss": "8.4.47",
+        "prettier": "3.3.3",
+        "prettier-plugin-organize-imports": "4.1.0",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "release-it": "17.10.0",
+        "rfc4648": "1.5.3",
+        "sass": "1.80.5",
+        "sass-loader": "16.0.3",
+        "storybook": "8.4.1",
+        "typeconv": "2.3.1",
+        "typescript": "5.6.3",
+        "ua-parser-js": "1.0.39",
+        "uuid": "11.0.2",
+        "vite": "5.4.14",
+        "vite-plugin-dts": "4.3.0",
+        "vitest": "2.1.4",
+        "vue-tsc": "2.1.10"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -60,126 +131,8 @@
       }
     },
     "node_modules/@belvo/payments-atoms": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@belvo/payments-atoms/-/payments-atoms-0.4.3.tgz",
-      "integrity": "sha512-xDy7B9+gjsNbjJwlLoL5HnbKST8bbvq9txykW8ICVZBz0qRQ5I+zWyl694h9NRRmMt+9aglPFEU4UcpKJn48jA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@github/webauthn-json": "^2.1.1",
-        "vue": "3.5.12"
-      }
-    },
-    "node_modules/@belvo/payments-atoms/node_modules/@vue/compiler-core": {
-      "version": "3.5.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.25.3",
-        "@vue/shared": "3.5.12",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.0"
-      }
-    },
-    "node_modules/@belvo/payments-atoms/node_modules/@vue/compiler-dom": {
-      "version": "3.5.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.12",
-        "@vue/shared": "3.5.12"
-      }
-    },
-    "node_modules/@belvo/payments-atoms/node_modules/@vue/compiler-sfc": {
-      "version": "3.5.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.25.3",
-        "@vue/compiler-core": "3.5.12",
-        "@vue/compiler-dom": "3.5.12",
-        "@vue/compiler-ssr": "3.5.12",
-        "@vue/shared": "3.5.12",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.11",
-        "postcss": "^8.4.47",
-        "source-map-js": "^1.2.0"
-      }
-    },
-    "node_modules/@belvo/payments-atoms/node_modules/@vue/compiler-ssr": {
-      "version": "3.5.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.12",
-        "@vue/shared": "3.5.12"
-      }
-    },
-    "node_modules/@belvo/payments-atoms/node_modules/@vue/reactivity": {
-      "version": "3.5.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "3.5.12"
-      }
-    },
-    "node_modules/@belvo/payments-atoms/node_modules/@vue/runtime-core": {
-      "version": "3.5.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.5.12",
-        "@vue/shared": "3.5.12"
-      }
-    },
-    "node_modules/@belvo/payments-atoms/node_modules/@vue/runtime-dom": {
-      "version": "3.5.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.5.12",
-        "@vue/runtime-core": "3.5.12",
-        "@vue/shared": "3.5.12",
-        "csstype": "^3.1.3"
-      }
-    },
-    "node_modules/@belvo/payments-atoms/node_modules/@vue/server-renderer": {
-      "version": "3.5.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-ssr": "3.5.12",
-        "@vue/shared": "3.5.12"
-      },
-      "peerDependencies": {
-        "vue": "3.5.12"
-      }
-    },
-    "node_modules/@belvo/payments-atoms/node_modules/@vue/shared": {
-      "version": "3.5.12",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@belvo/payments-atoms/node_modules/vue": {
-      "version": "3.5.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.12",
-        "@vue/compiler-sfc": "3.5.12",
-        "@vue/runtime-dom": "3.5.12",
-        "@vue/server-renderer": "3.5.12",
-        "@vue/shared": "3.5.12"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
+      "resolved": "../../..",
+      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.23.1",
@@ -693,16 +646,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@github/webauthn-json": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@github/webauthn-json/-/webauthn-json-2.1.1.tgz",
-      "integrity": "sha512-XrftRn4z75SnaJOmZQbt7Mk+IIjqVHw+glDGOxuHwXkZBZh/MBoRS7MHjSZMDaLhT4RjN2VqiEU7EOYleuJWSQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "webauthn-json": "dist/bin/main.js"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1946,7 +1889,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "5.4.11",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/biometricPix/playground/package.json
+++ b/examples/biometricPix/playground/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "watch": "vite build --watch",
     "preview": "vite preview",
     "lint": "eslint . --fix",
     "format": "prettier --write src/"

--- a/examples/biometricPix/playground/package.json
+++ b/examples/biometricPix/playground/package.json
@@ -15,7 +15,7 @@
     "vue": "^3.5.12"
   },
   "devDependencies": {
-    "@belvo/payments-atoms": "latest",
+    "@belvo/payments-atoms": "file:../../../",
     "@eslint/js": "^9.14.0",
     "@vitejs/plugin-vue": "^5.1.4",
     "@vue/eslint-config-prettier": "^10.1.0",

--- a/examples/biometricPix/playground/src/App.vue
+++ b/examples/biometricPix/playground/src/App.vue
@@ -157,11 +157,6 @@ const beautifyPaymentJson = () => {
 <template>
   <div id="app">
     <header class="header">
-      <img 
-        src="https://belvo.com/wp-content/themes/belvo/assets/img/belvo.svg" 
-        alt="Belvo Logo" 
-        class="belvo-logo"
-      />
       <h1 class="page-title">Biometric Pix Playground</h1>
     </header>
     <main class="three-column-layout">
@@ -255,12 +250,6 @@ const beautifyPaymentJson = () => {
   align-items: center;
   padding: 0.75rem 2rem;
   position: relative;
-}
-
-.belvo-logo {
-  height: 2rem;
-  position: absolute;
-  left: 2rem;
 }
 
 .page-title {

--- a/examples/biometricPix/playground/src/App.vue
+++ b/examples/biometricPix/playground/src/App.vue
@@ -1,60 +1,21 @@
 <script setup>
 import BelvoPaymentAtoms from '@belvo/payments-atoms';
 import { computed, ref, watch } from 'vue';
-import { generateUUID, generateRandomChallenge } from './utils';
+import { 
+  DEFAULT_ACCOUNT_TENURE,
+  DEFAULT_AUTHENTICATION_OPTIONS,
+  DEFAULT_REGISTRATION_OPTIONS,
+} from './constants';
 
-const DEFAULT_RP_ID = 'settling-workable-glider.ngrok-free.app';
 
-const accountTenure = ref('2023-04-05');
-
+// Risk Signals
+const accountTenure = ref(DEFAULT_ACCOUNT_TENURE);
 const enrollmentInformation = ref(null);
-const biometricAuthorization = ref(null);
+
+// Enrollment / Registration
 const biometricRegistrationConfirmation = ref(null);
-
-const biometricRegistrationRequest = ref({
-  rp: {
-      name: 'Belvo',
-      id: DEFAULT_RP_ID,
-  },
-  user: {
-      id: generateUUID(),
-      name: 'john.doe@bio.localhost',
-      displayName: 'John Doe',
-  },
-  challenge: generateRandomChallenge(),
-  pubKeyCredParams: [
-    { type: "public-key", alg: -7 }, // ES256
-    { type: "public-key", alg: -257 } // RS256
-  ],
-  timeout: 60000,
-  excludeCredentials: [
-    {
-      type: "public-key",
-      id: "CREDENTIAL-ID-HERE",
-    }
-  ],
-  authenticatorSelection: {
-    authenticatorAttachment: "platform",
-    residentKey: "discouraged",
-    requireResidentKey: false,
-    userVerification: "required"
-  },
-  attestation: 'direct',
-  attestationFormats: [
-    'android-safetynet',
-    'android-key',
-    'apple',
-    'fido-u2f',
-    'packed',
-    'tpm',
-    'none'
-  ],
-  extensions: {
-    credProps: true
-  }
-});
+const biometricRegistrationRequest = ref(DEFAULT_REGISTRATION_OPTIONS);
 const biometricRegistrationRequestText = ref(JSON.stringify(biometricRegistrationRequest.value, null, 2));
-
 const biometricRegistrationConfirmationJson = computed({
   get: () => {
     if (!biometricRegistrationConfirmation.value) return '';
@@ -69,23 +30,10 @@ const biometricRegistrationConfirmationJson = computed({
   }
 });
 
-const biometricPaymentRequest = ref({
-  challenge: generateRandomChallenge(),
-  timeout: 60000,
-  rpId: DEFAULT_RP_ID,
-  allowCredentials: [
-    {
-      type: "public-key",
-      id: "CREDENTIAL-ID-HERE",
-      transports: ["internal", "hybrid"],
-    }
-  ],
-  userVerification: "required",
-  hints: [],
-  extensions: {}
-});
+// Payment / Authorization
+const biometricAuthorization = ref(null);
+const biometricPaymentRequest = ref(DEFAULT_AUTHENTICATION_OPTIONS);
 const biometricPaymentRequestText = ref(JSON.stringify(biometricPaymentRequest.value, null, 2));
-
 const biometricAuthorizationJson = computed({
   get: () => {
     if (!biometricAuthorization.value) return '';

--- a/examples/biometricPix/playground/src/constants.js
+++ b/examples/biometricPix/playground/src/constants.js
@@ -1,0 +1,65 @@
+import { generateRandomChallenge, generateUUID } from './utils';
+
+// WebAuthn Registration Options
+const DEFAULT_RP_ID = 'bio.localhost';
+const RP_ID = import.meta.env.VITE_RP_ID || DEFAULT_RP_ID;
+
+export const DEFAULT_REGISTRATION_OPTIONS = {
+    rp: {
+        name: 'Belvo',
+        id: RP_ID,
+    },
+    user: {
+        id: generateUUID(),
+        name: 'john.doe@bio.localhost',
+        displayName: 'John Doe',
+    },
+    challenge: generateRandomChallenge(),
+    pubKeyCredParams: [
+        { type: 'public-key', alg: -7 },
+        { type: 'public-key', alg: -257 }
+    ],
+    timeout: 60000,
+    excludeCredentials: [
+        {
+        type: 'public-key',
+        id: 'CREDENTIAL-ID-HERE',
+        }
+    ],
+    authenticatorSelection: {
+        authenticatorAttachment: 'platform',
+        residentKey: 'discouraged',
+        requireResidentKey: false,
+        userVerification: 'required'
+    },
+    attestation: 'direct',
+    attestationFormats: [
+        'android-safetynet',
+        'android-key',
+        'apple',
+        'fido-u2f',
+        'packed',
+        'tpm',
+        'none'
+    ],
+    extensions: {
+        credProps: true
+    }
+}
+
+export const DEFAULT_AUTHENTICATION_OPTIONS = {
+    challenge: generateRandomChallenge(),
+    timeout: 60000,
+    rpId: RP_ID,
+    allowCredentials: [
+      {
+        type: 'public-key',
+        id: 'CREDENTIAL-ID-HERE',
+        transports: ['internal', 'hybrid'],
+      }
+    ],
+    userVerification: 'required'
+}
+
+// Risk Signals
+export const DEFAULT_ACCOUNT_TENURE = '2023-04-05';

--- a/examples/biometricPix/playground/src/utils.js
+++ b/examples/biometricPix/playground/src/utils.js
@@ -1,0 +1,16 @@
+export const generateUUID = () => {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      const r = Math.random() * 16 | 0;
+      const v = c === 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    });
+  };
+
+export const generateRandomChallenge = () => {
+    const array = new Uint8Array(32);
+    crypto.getRandomValues(array);
+    return btoa(String.fromCharCode.apply(null, array))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '');
+};

--- a/examples/biometricPix/playground/vite.config.js
+++ b/examples/biometricPix/playground/vite.config.js
@@ -5,7 +5,7 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/payments-atoms/examples/biometric-pix',
+  base: '/',
   plugins: [
     vue(),
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/node": "22.8.6",
         "@types/ua-parser-js": "0.7.39",
         "@types/uuid": "10.0.0",
-        "@types/webappsec-credential-management": "0.6.8",
+        "@types/webappsec-credential-management": "0.6.9",
         "@vitejs/plugin-vue": "5.1.4",
         "@vitest/coverage-v8": "2.1.4",
         "@vue/eslint-config-prettier": "10.1.0",
@@ -68,7 +68,7 @@
         "typescript": "5.6.3",
         "ua-parser-js": "1.0.39",
         "uuid": "11.0.2",
-        "vite": "5.4.10",
+        "vite": "5.4.14",
         "vite-plugin-dts": "4.3.0",
         "vitest": "2.1.4",
         "vue-tsc": "2.1.10"
@@ -3163,6 +3163,17 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
+    "node_modules/@types/react": {
+      "version": "19.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
+      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
@@ -3188,10 +3199,11 @@
       "dev": true
     },
     "node_modules/@types/webappsec-credential-management": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@types/webappsec-credential-management/-/webappsec-credential-management-0.6.8.tgz",
-      "integrity": "sha512-DES/SkK54U7AG8hmMkGCJkOSlywM3R+TzaWT+rBnX3lQTJ3K57jWr+UccWY8ImkuKekC9BjB+AH4zLJB4JKpvQ==",
-      "dev": true
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@types/webappsec-credential-management/-/webappsec-credential-management-0.6.9.tgz",
+      "integrity": "sha512-4uDknRaO9G1fonoEALN6SDYvyRb7luVYP7lm7y0OkdVdMcU7rIh+Nq/VepDe0arkh+gfUzwCr5cNfqmKm+x5wA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.10.0",
@@ -12073,7 +12085,7 @@
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12331,10 +12343,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.10.tgz",
-      "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "build-only": "vite build",
     "build": "run-p type-check \"build-only {@}\" --",
+    "watch": "vite build --watch",
     "test": "vitest",
     "test:ci": "vitest run --coverage --test-timeout=10000 --retry=2",
     "coverage": "vitest run --coverage",
@@ -62,7 +63,7 @@
     "@types/node": "22.8.6",
     "@types/ua-parser-js": "0.7.39",
     "@types/uuid": "10.0.0",
-    "@types/webappsec-credential-management": "0.6.8",
+    "@types/webappsec-credential-management": "0.6.9",
     "@vitejs/plugin-vue": "5.1.4",
     "@vitest/coverage-v8": "2.1.4",
     "@vue/eslint-config-prettier": "10.1.0",
@@ -101,7 +102,7 @@
     "typescript": "5.6.3",
     "ua-parser-js": "1.0.39",
     "uuid": "11.0.2",
-    "vite": "5.4.10",
+    "vite": "5.4.14",
     "vite-plugin-dts": "4.3.0",
     "vitest": "2.1.4",
     "vue-tsc": "2.1.10"

--- a/src/services/pix/authentication.ts
+++ b/src/services/pix/authentication.ts
@@ -1,0 +1,95 @@
+/**
+ * While we currently use the webauthn-json library, many of its features are now natively
+ * supported in WebAuthn Level 3, including JSON serialization/deserialization. Once these
+ * features are widely supported across all major browsers, we can migrate to using the
+ * native WebAuthn API directly.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API}
+ */
+
+import { BiometricAuthorization, BiometricPaymentRequest } from '@/types/pix'
+import {
+  AuthenticationResponseJSON,
+  get,
+  parseRequestOptionsFromJSON
+} from '@github/webauthn-json/browser-ponyfill'
+import { PublicKeyCredentialRequestOptionsJSON } from '@github/webauthn-json/dist/types/basic/json'
+import { optionalField } from '../utils'
+import { BELVO_RP_ID } from './constants'
+import { handleBiometricError, handleCredentialNotFound } from './errors'
+import { PublicKeyCredentialWithAssertionResponse, WebauthnCredentialRequestOptions } from './types'
+
+/**
+ * Ensure we use Belvo's RP ID.
+ * This field is optional, but we enforce it to ensure compatibility with the Open Finance use case.
+ * @see {@link https://openbanking-brasil.github.io/openapi/swagger-apis/enrollments/?urls.primaryName=2.1.0#/V%C3%ADnculo%20de%20dispositivo/enrollmentCreateFidoSigningOptions}
+ */
+const _enforceBelvoRpId = () => BELVO_RP_ID
+
+/**
+ * Ensure we use the correct user verification method.
+ * This is required by the Open Finance use case.
+ */
+const _enforceUserVerification = () => 'required'
+
+/**
+ * For Open Finance, the user handle must be a valid base-64url encoded string (non-null).
+ * @see {@link https://openbanking-brasil.github.io/openapi/swagger-apis/enrollments/?urls.primaryName=2.1.0#/Consentimento/authorizeConsent}
+ */
+const _enforceOpenFinanceCompliantUserHandle = (
+  userHandle: AuthenticationResponseJSON['response']['userHandle']
+): string => {
+  return userHandle || ''
+}
+
+/**
+ * @see {@link https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialrequestoptions}
+ */
+const buildCredentialRequestOptions = (
+  authenticationRequest: BiometricPaymentRequest
+): WebauthnCredentialRequestOptions => {
+  const publicKey: PublicKeyCredentialRequestOptionsJSON = {
+    challenge: authenticationRequest.challenge,
+    ...optionalField('timeout', authenticationRequest.timeout),
+    ...optionalField('rpId', _enforceBelvoRpId()),
+    ...optionalField('allowCredentials', authenticationRequest.allowCredentials),
+    ...optionalField('userVerification', _enforceUserVerification()),
+    ...optionalField('extensions', authenticationRequest.extensions)
+  }
+
+  return parseRequestOptionsFromJSON({ publicKey }) as WebauthnCredentialRequestOptions
+}
+
+/**
+ * @see {@link https://www.w3.org/TR/webauthn-3/#publickeycredential}
+ * @see {@link https://www.w3.org/TR/webauthn-3/#authenticatorassertionresponse}
+ */
+const buildBiometricAuthorization = (
+  credential: PublicKeyCredentialWithAssertionResponse
+): BiometricAuthorization => {
+  const json: AuthenticationResponseJSON = credential.toJSON()
+
+  return {
+    ...json,
+    response: {
+      ...json.response,
+      userHandle: _enforceOpenFinanceCompliantUserHandle(json.response.userHandle)
+    }
+  } as BiometricAuthorization
+}
+
+export const authenticateCredential = async (
+  authenticationRequest: BiometricPaymentRequest
+): Promise<BiometricAuthorization | null> => {
+  const options = buildCredentialRequestOptions(authenticationRequest)
+
+  try {
+    const credential = await get(options)
+    if (!credential) {
+      throw handleCredentialNotFound()
+    }
+
+    return buildBiometricAuthorization(credential as PublicKeyCredentialWithAssertionResponse)
+  } catch (error) {
+    throw handleBiometricError(error)
+  }
+}

--- a/src/services/pix/constants.ts
+++ b/src/services/pix/constants.ts
@@ -1,0 +1,1 @@
+export const BELVO_RP_ID = 'belvo.com'

--- a/src/services/pix/registration.ts
+++ b/src/services/pix/registration.ts
@@ -1,0 +1,102 @@
+/**
+ * While we currently use the webauthn-json library, many of its features are now natively
+ * supported in WebAuthn Level 3, including JSON serialization/deserialization. Once these
+ * features are widely supported across all major browsers, we can migrate to using the
+ * native WebAuthn API directly.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API}
+ */
+
+import { BiometricRegistrationConfirmation, BiometricRegistrationRequest } from '@/types/pix'
+import { create, parseCreationOptionsFromJSON } from '@github/webauthn-json/browser-ponyfill'
+import { PublicKeyCredentialCreationOptionsJSON } from '@github/webauthn-json/dist/types/basic/json'
+import { optionalField } from '../utils'
+import { BELVO_RP_ID } from './constants'
+import { handleBiometricError, handleCredentialNotFound } from './errors'
+import { WebauthnCredentialCreationOptions } from './types'
+
+/**
+ * Ensure we use Belvo's RP ID.
+ * This is validated against our Open Finance BRCAC certificate.
+ * @see {@link https://openbanking-brasil.github.io/openapi/swagger-apis/enrollments/?urls.primaryName=2.1.0#/V%C3%ADnculo%20de%20dispositivo/enrollmentCreateFidoRegistrationOptions}
+ */
+const _enforceBelvoRpId = (rp: BiometricRegistrationRequest['rp']) =>
+  rp.id !== BELVO_RP_ID
+    ? {
+        ...rp,
+        id: BELVO_RP_ID
+      }
+    : rp
+
+/**
+ * Ensure authenticator selection criteria for better user experience.
+ * @see {@link https://www.w3.org/TR/webauthn-3/#dictdef-authenticatorselectioncriteria}
+ */
+const _enforceAuthenticatorSelection =
+  (): BiometricRegistrationRequest['authenticatorSelection'] => {
+    return {
+      /**
+       * Ensure Security Key or Bluetooth is not used, and
+       * display fingerprint sensor or face sensor straight away.
+       */
+      authenticatorAttachment: 'platform',
+
+      /**
+       * Ensure we do not create a Passkey.
+       * They are not useful for the Open Finance use case, as Enrollments are
+       * limited by the device ID and we cannot use them across devices.
+       */
+      residentKey: 'discouraged',
+      requireResidentKey: false,
+
+      /**
+       * Ensure we use fingerprint sensor or face sensor to validate user presence.
+       * This is required by the Open Finance use case.
+       */
+      userVerification: 'required'
+    }
+  }
+
+/**
+ * @see {@link https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialcreationoptions}
+ */
+export const buildCredentialCreationOptions = (
+  registrationRequest: BiometricRegistrationRequest
+): WebauthnCredentialCreationOptions => {
+  const rp = _enforceBelvoRpId(registrationRequest.rp)
+  const authenticatorSelection = _enforceAuthenticatorSelection()
+
+  const publicKey: PublicKeyCredentialCreationOptionsJSON = {
+    rp,
+    user: registrationRequest.user,
+    challenge: registrationRequest.challenge,
+    pubKeyCredParams: registrationRequest.pubKeyCredParams,
+    ...optionalField('timeout', registrationRequest.timeout),
+    ...optionalField('authenticatorSelection', authenticatorSelection),
+    ...optionalField('attestation', registrationRequest.attestation),
+    ...optionalField('attestationFormats', registrationRequest.attestationFormats),
+    ...optionalField('extensions', registrationRequest.extensions)
+    /**
+     * We are not setting excludeCredentials on purpose, as we want to allow the user to
+     * create as many credentials as they want.
+     */
+  }
+
+  return parseCreationOptionsFromJSON({ publicKey }) as WebauthnCredentialCreationOptions
+}
+
+export const registerCredential = async (
+  registrationRequest: BiometricRegistrationRequest
+): Promise<BiometricRegistrationConfirmation> => {
+  const options = buildCredentialCreationOptions(registrationRequest)
+
+  try {
+    const credential = await create(options)
+    if (!credential) {
+      throw handleCredentialNotFound()
+    }
+
+    return credential.toJSON() as BiometricRegistrationConfirmation
+  } catch (error) {
+    throw handleBiometricError(error)
+  }
+}

--- a/src/services/pix/types.ts
+++ b/src/services/pix/types.ts
@@ -1,0 +1,30 @@
+import { AuthenticationPublicKeyCredential } from '@github/webauthn-json/dist/types/browser-ponyfill'
+
+/**
+ * This type is a narrower version of CredentialCreationOptions,
+ * that is used to create a PublicKeyCredential and ensure
+ * that the options are valid for the Webauthn API.
+ * @see {@link https://www.w3.org/TR/webauthn-3/#sctn-credentialcreationoptions-extension}
+ */
+export type WebauthnCredentialCreationOptions = CredentialCreationOptions & {
+  publicKey: PublicKeyCredentialCreationOptions
+}
+
+/**
+ * This type is a narrower version of CredentialRequestOptions,
+ * that is used to request a PublicKeyCredential and ensure
+ * that the options are valid for the Webauthn API.
+ * @see {@link https://www.w3.org/TR/webauthn-3/#sctn-credentialrequestoptions-extension}
+ */
+export type WebauthnCredentialRequestOptions = CredentialRequestOptions & {
+  publicKey: PublicKeyCredentialRequestOptions
+}
+
+/**
+ * This type is a narrower version of PublicKeyCredential,
+ * that is used to ensure the requested credential is valid for the Webauthn API.
+ * @see {@link https://www.w3.org/TR/webauthn-3/#authenticatorassertionresponse}
+ */
+export type PublicKeyCredentialWithAssertionResponse = AuthenticationPublicKeyCredential & {
+  response: AuthenticatorAssertionResponse
+}

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Creates an object with a single key-value pair if the value is defined, otherwise returns an empty object.
+ * This utility is useful for conditionally adding properties to objects.
+ *
+ * @param key - The key to use in the resulting object
+ * @param value - The optional value to associate with the key
+ * @returns An object with the key-value pair if value is defined, or an empty object if value is undefined
+ *
+ * @example
+ * optionalField('name', 'John')  // Returns { name: 'John' }
+ * optionalField('age', undefined) // Returns {}
+ * optionalField('count', 0)      // Returns { count: 0 }
+ * optionalField('items', null)    // Returns { items: null }
+ */
+export const optionalField = (key: string, value?: unknown) => (value ? { [key]: value } : {})

--- a/src/types/pix.ts
+++ b/src/types/pix.ts
@@ -1,33 +1,9 @@
-export type BiometricRegistrationRequestUser = {
-  id: string
-  name: PublicKeyCredentialCreationOptions['user']['name']
-  displayName: PublicKeyCredentialCreationOptions['user']['displayName']
-}
-
-export type BiometricRegistrationRequest = {
-  challenge: string
-  rp: PublicKeyCredentialCreationOptions['rp']
-  user: BiometricRegistrationRequestUser
-  pubKeyCredParams: PublicKeyCredentialCreationOptions['pubKeyCredParams']
-  accountTenure: string
-  attestation?: PublicKeyCredentialCreationOptions['attestation']
-  timeout?: PublicKeyCredentialCreationOptions['timeout']
-  excludeCredentials?: PublicKeyCredentialCreationOptions['excludeCredentials']
-  authenticatorSelection?: PublicKeyCredentialCreationOptions['authenticatorSelection']
-  extensions?: PublicKeyCredentialCreationOptions['extensions']
-}
-
-export type BiometricPaymentRequest = {
-  challenge: string
-  timeout?: number
-  rpId?: string
-  allowCredentials?: {
-    id: string
-    type: string
-  }[]
-  userVerification: UserVerificationRequirement
-  extensions?: PublicKeyCredentialRequestOptions['extensions']
-}
+import {
+  AuthenticationResponseJSON,
+  CredentialCreationOptionsJSON,
+  CredentialRequestOptionsJSON,
+  RegistrationResponseJSON
+} from '@github/webauthn-json/browser-ponyfill'
 
 export type EnrollmentInformation = {
   osVersion: string
@@ -40,30 +16,43 @@ export type EnrollmentInformation = {
   accountTenure: string
 }
 
-export type BiometricAuthorization = {
-  id: string
-  rawId: string
-  response: {
-    authenticatorData: string
-    clientDataJSON: string
-    signature: string
-    userHandle: string | null
-  }
-  type: string
-}
-
-export type BiometricRegistrationConfirmation = {
-  id: string
-  authenticatorAttachment: string
-  rawId: string
-  response: {
-    attestationObject: string
-    clientDataJSON: string
-  }
-  type: string
-}
-
 export type DeviceInformation = {
   visitorId: string
   sealedResult?: string
+}
+
+/**
+ * @see {@link https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialcreationoptionsjson}
+ */
+export type BiometricRegistrationRequest = CredentialCreationOptionsJSON['publicKey'] & {
+  /**
+   * TODO: Remove this type extension once the full TypeScript WebAuthn Level 3 types are available.
+   */
+  attestationFormats?: string[]
+}
+
+/**
+ * TODO: replace RegistrationResponseJSON with the TypeScript DOM once TS fully supports WebAuthn Level 3.
+ * @see {@link https://www.w3.org/TR/webauthn-3/#dictdef-registrationresponsejson}
+ */
+export type BiometricRegistrationConfirmation = RegistrationResponseJSON
+
+/**
+ * @see {@link https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialrequestoptionsjson}
+ */
+export type BiometricPaymentRequest = Required<Pick<CredentialRequestOptionsJSON, 'publicKey'>> &
+  CredentialRequestOptionsJSON['publicKey']
+
+/**
+ * TODO: replace AuthenticationResponseJSON with the TypeScript DOM once TS fully supports WebAuthn Level 3.
+ * @see {@link https://www.w3.org/TR/webauthn-3/#dictdef-authenticationresponsejson}
+ */
+export type BiometricAuthorization = AuthenticationResponseJSON & {
+  response: {
+    /**
+     * For Open Finance, the user handle must be a valid base-64url encoded string (not null).
+     * @see {@link https://openbanking-brasil.github.io/openapi/swagger-apis/enrollments/?urls.primaryName=2.1.0#/Consentimento/authorizeConsent}
+     */
+    userHandle: string
+  }
 }


### PR DESCRIPTION
- Make sure credential registration doesn't create Passkeys on Android
and prompt for fingerprint straight away.
- Do not allow usage of cross-platform authenticators (e.g. Security Keys)
- Enforce usage of belvo.com RP ID to avoid security errors
from the authenticators and comply with Open Finance.
- Ensure all optional fields are properly handled and passed to the authenticator.
- PURPOSELY leave out excludeCredentials from the registration,
to not limit creation of Enrollments.
- Split registration and authentication logic in their own files for better
readability and code organization.
- Streamline WebAuthn type annotations, aiming at keeping consistency with
WebAuthn Level 3 for later removal of the webauthn-json library.
- Remove type assertions is favor of custom types, for better TypeScript support
and readability.